### PR TITLE
fix: use `echo "{name}={value}" >> $GITHUB_OUTPUT` for setting output variables

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -155,8 +155,8 @@ wait_for_workflow_to_finish() {
   echo "Waiting for workflow to finish:"
   echo "The workflow id is [${last_workflow_id}]."
   echo "The workflow logs can be found at ${last_workflow_url}"
-  echo "::set-output name=workflow_id::${last_workflow_id}"
-  echo "::set-output name=workflow_url::${last_workflow_url}"
+  echo "workflow_id=${last_workflow_id}" >> $GITHUB_OUTPUT
+  echo "workflow_url=${last_workflow_url}" >> $GITHUB_OUTPUT
   echo ""
 
   conclusion=null


### PR DESCRIPTION
### fix: use `echo "{name}={value}" >> $GITHUB_OUTPUT` for setting output variables

The idiom:

```bash
echo "::set-output name={name}::{value}"
```

is deprecated and causes github to issue the warning:

>  Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This commit replaces it with:

```bash
echo "{name}={value}" >> $GITHUB_OUTPUT
```
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


### Preview

Compare the results with the fixes vs without:

- **with the fixes** https://github.com/cloudbeds/mapping-service/actions/runs/5177776952
- **without the fixes** https://github.com/cloudbeds/mapping-service/actions/runs/5119063067

![image](https://github.com/cloudbeds/trigger-workflow-and-wait/assets/56197/b6bc3e60-aa64-4737-a731-e7162a894a60)
