### PR TITLE
fix: use public.ecr.aws/docker/library/alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM public.ecr.aws/docker/library/alpine:3.15.0
 
 RUN apk update && apk --no-cache add curl jq coreutils
 


### PR DESCRIPTION
### fix: use public.ecr.aws/docker/library/alpine

We're getting rate limited by docker.io when pulling the alpine docker image.

We're changing it to a different registry that's less prone to rate limiting.


### Example

Here's a PR that failed due to the rate limiting https://github.com/cloudbeds/user-service/actions/runs/7529304828/job/20493395609#step:2:16

```
#3 [internal] load metadata for docker.io/library/alpine:3.15.0
  #3 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/alpine/manifests/sha256:21a3deaa0d32a80579[14](https://github.com/cloudbeds/user-service/actions/runs/7529304828/job/20493395609#step:2:14)f36584b5288d2e5ecc984380bc0118285c70fa8c9300: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
  ------
   > [internal] load metadata for docker.io/library/alpine:3.15.0:
  ------
  Dockerfile:1
  --------------------
     1 | >>> FROM alpine:3.15.0
     2 |     
     3 |     RUN apk update && apk --no-cache add curl jq coreutils
  --------------------
  ERROR: failed to solve: alpine:3.15.0: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/alpine/manifests/sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
  Warning: Docker build failed with exit code 1, back off 7.305 seconds before retry.
```