### PR TITLE
fix(ci): don't prevent CI runs if we only change .github/ files

### DIFF
--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -6,7 +6,6 @@ on:
       - main
     paths-ignore:
       - '**.md'
-      - '.github/**'
 
 jobs:
   build-push:

--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-push:
     name: Build and push application image
-    runs-on: ubuntu-latest
+    runs-on: default
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -10,7 +10,7 @@ jobs:
 
   re-tag:
     name: Re-tag image
-    runs-on: ubuntu-latest
+    runs-on: default
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### fix(ci): don't prevent CI runs if we only change .github/ files

Even if a commit has changes only to the .github/ files we still want to trigger a run of the CI which can potentially build the docker images.



### feat(ci): switch to our custom runners (`default`)

These runners are cheaper and more reliable than the github default runners.