### PR TITLE
Revert "feat(ci): switch to our custom runners (`default`)"

### DIFF
--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-push:
     name: Build and push application image
-    runs-on: default
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -10,7 +10,7 @@ jobs:
 
   re-tag:
     name: Re-tag image
-    runs-on: default
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### Revert "feat(ci): switch to our custom runners (`default`)"

This reverts commit aa15b520fbe6132e3c1929e78f0300c5f18dae2c.

Turns out that the project is public and we don't share our custom runners with public repos.

Until we find out why this is public we better revert this change.