### PR TITLE
ci: run docker builds from PRs

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,31 @@
+name: Build docker image
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: Indicates if the docker image has to be pushed
+        type: boolean
+        default: false
+    outputs:
+      image-tag:
+        description: Image tag used
+        value: ${{ github.event.pull_request.head.sha || github.sha }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Docker Build 🐋
+    runs-on: x1-core
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    steps:
+      - name: Docker build
+        uses: cloudbeds/composite-actions/docker/build-push/remote@v2
+        with:
+          push: ${{ inputs.push }}

--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -10,13 +10,7 @@ on:
 jobs:
   build-push:
     name: Build and push application image
-    runs-on: x1-core
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-
-      - name: Build and push application image
-        uses: cloudbeds/composite-actions/docker/build-push/remote@v2
-        with:
-          push: true
+    uses: ./.github/workflows/docker-build.yaml
+    secrets: inherit
+    with:
+      push: true

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,21 @@
+name: Pull Request
+
+on:
+  pull_request:
+
+# Cancel existing workflows running for this PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  docker-build:
+    name: Docker Build
+    uses: ./.github/workflows/docker-build.yaml
+    secrets: inherit
+    with:
+      push: false


### PR DESCRIPTION
### ci: run docker builds from PRs

This way we can test if we break the build process from a PR.



### ci: docker build is now done with a shared workflow

This will allow us to run the workflow in PRs.