### PR TITLE
ci: add support for arm64 docker images

### DIFF
--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -20,3 +20,4 @@ jobs:
         uses: cloudbeds/composite-actions/docker/build-push/remote@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
### ci: add support for arm64 docker images

The project is now building arm64 and amd64 images. The final goal is to
deploy arm64 images in our EKS cluster as the Graviton (ARM64) nodes are
cheaper and more efficient than their Intel/AMD64 counterpart.

The first step is to build docker images for both amd64 and arm64. This
commit does just that.

See PEN-359